### PR TITLE
wip: Neural Economic Growth Advisor scaffolding

### DIFF
--- a/backend/alembic/versions/20260219_0004_add_financial_profile.py
+++ b/backend/alembic/versions/20260219_0004_add_financial_profile.py
@@ -1,0 +1,52 @@
+"""Add financial_profiles table for Growth Advisor
+
+Revision ID: 20260219_0004
+Revises: 20260201_0003
+Create Date: 2026-02-19
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision = '20260219_0004'
+down_revision = '20260201_0003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'financial_profiles',
+        sa.Column('id', sa.Integer(), nullable=False),
+        # Location & immigration
+        sa.Column('country_of_residence', sa.String(length=2), nullable=False, server_default='CA'),
+        sa.Column('province_or_state', sa.String(length=10), nullable=True),
+        sa.Column('citizenship', sa.String(length=2), nullable=True),
+        sa.Column('visa_type', sa.String(length=30), nullable=True, server_default='citizen'),
+        # Income
+        sa.Column('annual_gross_income', sa.Numeric(precision=18, scale=2), nullable=False, server_default='0'),
+        sa.Column('income_currency', sa.String(length=10), nullable=False, server_default='CAD'),
+        sa.Column('employment_type', sa.String(length=30), nullable=False, server_default='employee'),
+        # Cash flow
+        sa.Column('monthly_expenses', sa.Numeric(precision=18, scale=2), nullable=False, server_default='0'),
+        sa.Column('monthly_savings', sa.Numeric(precision=18, scale=2), nullable=False, server_default='0'),
+        # Goals
+        sa.Column('goals', JSONB, nullable=True),
+        # Planning horizon
+        sa.Column('target_retirement_age', sa.Integer(), nullable=True),
+        sa.Column('current_age', sa.Integer(), nullable=True),
+        sa.Column('projection_years', sa.Integer(), nullable=False, server_default='10'),
+        # Notes
+        sa.Column('notes', sa.Text(), nullable=True),
+        # Timestamps
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('financial_profiles')

--- a/backend/db/models/financial_profile.py
+++ b/backend/db/models/financial_profile.py
@@ -1,0 +1,129 @@
+"""Financial profile model for the Neural Economic Growth Advisor.
+
+Canopy - Personal Finance Platform
+
+Stores the user's financial situation, goals, and preferences
+for tax-aware cross-border wealth projections.
+"""
+
+import enum
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import DateTime, Enum, Integer, Numeric, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.db.base import Base
+
+
+class VisaType(str, enum.Enum):
+    """Visa/immigration status."""
+    CITIZEN = "citizen"
+    PERMANENT_RESIDENT = "permanent_resident"
+    WORK_PERMIT = "work_permit"
+    TN = "tn"           # TN visa (CA/MX professionals in US)
+    H1B = "h1b"
+    L1 = "l1"
+    O1 = "o1"
+    STUDENT = "student"
+    OTHER = "other"
+
+
+class EmploymentType(str, enum.Enum):
+    """Employment classification for tax purposes."""
+    EMPLOYEE = "employee"
+    CONTRACTOR = "contractor"
+    SELF_EMPLOYED = "self_employed"
+
+
+class AdvisorGoal(str, enum.Enum):
+    """Financial and life goals for planning."""
+    FIRE = "fire"                         # Financial independence / retire early
+    GREEN_CARD = "green_card"             # Obtain US permanent residency
+    RELOCATION_US = "relocation_us"       # Move to the US
+    RELOCATION_CA = "relocation_ca"       # Move to Canada
+    RELOCATION_BR = "relocation_br"       # Move to Brazil
+    HOME_PURCHASE = "home_purchase"       # Buy a home
+    FHSA_ELIGIBLE = "fhsa_eligible"       # First Home Savings Account eligible
+    MINIMIZE_TAX = "minimize_tax"         # Optimize for lowest tax burden
+    MAXIMIZE_GROWTH = "maximize_growth"   # Optimize for highest net worth
+
+
+class FinancialProfile(Base):
+    """User's financial profile for the Growth Advisor.
+
+    Single-user app — at most one row. Stores all inputs needed
+    for tax-aware multi-year projections.
+    """
+
+    __tablename__ = "financial_profiles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # --- Location & Immigration ---
+    country_of_residence: Mapped[str] = mapped_column(
+        String(2), nullable=False, default="CA"
+    )  # ISO 3166-1 alpha-2: CA, US, BR
+    province_or_state: Mapped[Optional[str]] = mapped_column(
+        String(10), nullable=True
+    )  # e.g. ON, BC, NY, CA (US state)
+    citizenship: Mapped[Optional[str]] = mapped_column(
+        String(2), nullable=True
+    )  # Country of citizenship ISO code
+    visa_type: Mapped[Optional[str]] = mapped_column(
+        String(30), nullable=True, default=VisaType.CITIZEN.value
+    )
+
+    # --- Income ---
+    annual_gross_income: Mapped[Decimal] = mapped_column(
+        Numeric(precision=18, scale=2), nullable=False, default=Decimal("0")
+    )
+    income_currency: Mapped[str] = mapped_column(
+        String(10), nullable=False, default="CAD"
+    )
+    employment_type: Mapped[str] = mapped_column(
+        String(30), nullable=False, default=EmploymentType.EMPLOYEE.value
+    )
+
+    # --- Cash Flow ---
+    monthly_expenses: Mapped[Decimal] = mapped_column(
+        Numeric(precision=18, scale=2), nullable=False, default=Decimal("0")
+    )
+    monthly_savings: Mapped[Decimal] = mapped_column(
+        Numeric(precision=18, scale=2), nullable=False, default=Decimal("0")
+    )
+
+    # --- Goals (stored as JSON array of AdvisorGoal values) ---
+    goals: Mapped[Optional[list]] = mapped_column(
+        JSONB, nullable=True, default=list
+    )
+
+    # --- Planning Horizon ---
+    target_retirement_age: Mapped[Optional[int]] = mapped_column(
+        Integer, nullable=True
+    )
+    current_age: Mapped[Optional[int]] = mapped_column(
+        Integer, nullable=True
+    )
+    projection_years: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=10
+    )
+
+    # --- Notes ---
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    # --- Timestamps ---
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<FinancialProfile(country={self.country_of_residence}, "
+            f"income={self.annual_gross_income} {self.income_currency})>"
+        )

--- a/backend/services/account_optimizer.py
+++ b/backend/services/account_optimizer.py
@@ -1,0 +1,512 @@
+"""Account Optimizer for the Neural Economic Growth Advisor.
+
+Canopy - Personal Finance Platform
+
+Given a user's financial profile and existing assets, generates
+an ordered contribution priority ladder for tax efficiency.
+
+Priority logic:
+- Canada: Employer match -> RRSP (high bracket) -> TFSA -> FHSA (if eligible) -> Non-reg
+- USA: Employer match -> 401(k) -> Roth IRA (if eligible) -> Taxable
+- Cross-border relocation flags: Roth before leaving US, RRSP treaty protection
+
+All dollar amounts are in the user's income_currency from their profile.
+"""
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Optional
+
+from backend.db.models.financial_profile import AdvisorGoal, EmploymentType, VisaType
+from backend.services.tax_rules_engine import TaxRulesEngine
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AccountRecommendation:
+    """A single entry in the contribution priority ladder."""
+    rank: int
+    account_type: str          # e.g. "RRSP", "TFSA", "401k", "Roth IRA"
+    annual_amount: Decimal     # Recommended annual contribution
+    annual_limit: Decimal      # Max allowed by law
+    tax_benefit: str           # "pre-tax", "tax-free growth", "taxable"
+    tax_savings_estimate: Decimal  # Estimated tax saved vs contributing to taxable
+    reason: str                # Human-readable rationale
+    action: str                # Specific action step
+    priority: str              # "essential", "high", "medium", "low"
+    is_cross_border_note: bool = False
+    cross_border_note: Optional[str] = None
+
+
+@dataclass
+class OptimizationResult:
+    """Complete account optimization result."""
+    total_available_to_invest: Decimal
+    total_tax_sheltered_capacity: Decimal
+    recommendations: list[AccountRecommendation] = field(default_factory=list)
+    unallocated_amount: Decimal = Decimal("0")
+    total_estimated_tax_savings: Decimal = Decimal("0")
+    summary: str = ""
+    cross_border_alerts: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Optimizer
+# ---------------------------------------------------------------------------
+
+class AccountOptimizer:
+    """Generates tax-optimized contribution ladders."""
+
+    # RRSP optimization threshold: if marginal rate >= this, RRSP preferred over TFSA
+    RRSP_PREFERRED_MARGINAL_RATE = Decimal("0.26")
+
+    def __init__(self, tax_engine: Optional[TaxRulesEngine] = None):
+        self.tax = tax_engine or TaxRulesEngine()
+
+    def optimize(
+        self,
+        country: str,
+        province_or_state: Optional[str],
+        annual_gross_income: Decimal,
+        monthly_savings: Decimal,
+        employment_type: str,
+        visa_type: Optional[str],
+        goals: Optional[list[str]],
+        current_age: Optional[int],
+        year: int = 2025,
+    ) -> OptimizationResult:
+        """Generate ordered contribution recommendations.
+
+        Args:
+            country: "CA" or "US"
+            province_or_state: Province (ON, BC...) or US state
+            annual_gross_income: Gross annual income in local currency
+            monthly_savings: Available monthly savings to invest
+            employment_type: "employee", "contractor", "self_employed"
+            visa_type: Visa/immigration status
+            goals: List of AdvisorGoal values
+            current_age: User's age (for catch-up limits)
+            year: Tax year for limits
+        """
+        goals = goals or []
+        annual_savings = monthly_savings * 12
+
+        tax_result = self.tax.calculate_tax(
+            country, province_or_state, annual_gross_income, year
+        )
+        limits = self.tax.get_contribution_limits(
+            country, year, annual_gross_income, current_age
+        )
+
+        if country == "CA":
+            return self._optimize_canada(
+                annual_gross_income, annual_savings, employment_type,
+                visa_type, goals, current_age, year, tax_result, limits,
+                province_or_state
+            )
+        elif country == "US":
+            return self._optimize_usa(
+                annual_gross_income, annual_savings, employment_type,
+                visa_type, goals, current_age, year, tax_result, limits,
+                province_or_state
+            )
+        else:
+            return self._optimize_generic(annual_savings)
+
+    def _optimize_canada(
+        self,
+        income, annual_savings, employment_type, visa_type, goals,
+        age, year, tax_result, limits, province
+    ) -> OptimizationResult:
+        recommendations = []
+        remaining = annual_savings
+        rank = 1
+        marginal = tax_result.marginal_rate
+        cross_border_alerts = []
+
+        # RRSP limit
+        rrsp_limit = limits.rrsp_limit or Decimal("0")
+        tfsa_limit = limits.tfsa_limit or Decimal("0")
+        fhsa_limit = limits.fhsa_limit or Decimal("0")
+
+        # 1. RRSP vs TFSA decision based on marginal rate
+        if marginal >= self.RRSP_PREFERRED_MARGINAL_RATE:
+            # High earner: RRSP first (deduction at high rate, withdraw at low rate)
+            rrsp_contribution = min(remaining, rrsp_limit)
+            tax_savings = rrsp_contribution * marginal
+            recommendations.append(AccountRecommendation(
+                rank=rank,
+                account_type="RRSP",
+                annual_amount=rrsp_contribution,
+                annual_limit=rrsp_limit,
+                tax_benefit="pre-tax",
+                tax_savings_estimate=tax_savings,
+                reason=(
+                    f"Your marginal tax rate is {float(marginal*100):.1f}% — "
+                    "RRSP contributions reduce taxable income at this high rate. "
+                    "Withdrawals in retirement typically occur at a lower rate."
+                ),
+                action=f"Contribute ${rrsp_contribution:,.0f} to your RRSP this year "
+                       f"(room: ${rrsp_limit:,.0f}).",
+                priority="essential" if rrsp_contribution > 0 else "medium",
+            ))
+            remaining -= rrsp_contribution
+            rank += 1
+
+            # TFSA next
+            tfsa_contribution = min(remaining, tfsa_limit)
+            recommendations.append(AccountRecommendation(
+                rank=rank,
+                account_type="TFSA",
+                annual_amount=tfsa_contribution,
+                annual_limit=tfsa_limit,
+                tax_benefit="tax-free growth",
+                tax_savings_estimate=tfsa_contribution * Decimal("0.10"),
+                reason=(
+                    "TFSA growth and withdrawals are fully tax-free. "
+                    "Ideal for medium-term savings and flexible access."
+                ),
+                action=f"Contribute ${tfsa_contribution:,.0f} to your TFSA "
+                       f"(annual room: ${tfsa_limit:,.0f}).",
+                priority="high",
+            ))
+            remaining -= tfsa_contribution
+            rank += 1
+        else:
+            # Lower earner: TFSA first (marginal rate too low for RRSP deduction to shine)
+            tfsa_contribution = min(remaining, tfsa_limit)
+            recommendations.append(AccountRecommendation(
+                rank=rank,
+                account_type="TFSA",
+                annual_amount=tfsa_contribution,
+                annual_limit=tfsa_limit,
+                tax_benefit="tax-free growth",
+                tax_savings_estimate=tfsa_contribution * Decimal("0.10"),
+                reason=(
+                    f"Your marginal rate is {float(marginal*100):.1f}% — "
+                    "TFSA is preferred when the RRSP deduction benefit is modest. "
+                    "Tax-free growth compounds without future withdrawal tax."
+                ),
+                action=f"Contribute ${tfsa_contribution:,.0f} to your TFSA "
+                       f"(annual room: ${tfsa_limit:,.0f}).",
+                priority="essential",
+            ))
+            remaining -= tfsa_contribution
+            rank += 1
+
+            rrsp_contribution = min(remaining, rrsp_limit)
+            if rrsp_contribution > 0:
+                tax_savings = rrsp_contribution * marginal
+                recommendations.append(AccountRecommendation(
+                    rank=rank,
+                    account_type="RRSP",
+                    annual_amount=rrsp_contribution,
+                    annual_limit=rrsp_limit,
+                    tax_benefit="pre-tax",
+                    tax_savings_estimate=tax_savings,
+                    reason=(
+                        "RRSP still provides a tax deduction and tax-deferred growth. "
+                        "Useful for building retirement income and smoothing taxes."
+                    ),
+                    action=f"Contribute ${rrsp_contribution:,.0f} to your RRSP.",
+                    priority="medium",
+                ))
+                remaining -= rrsp_contribution
+                rank += 1
+
+        # FHSA if home purchase is a goal
+        if AdvisorGoal.HOME_PURCHASE in goals or AdvisorGoal.FHSA_ELIGIBLE in goals:
+            fhsa_contribution = min(remaining, fhsa_limit)
+            if fhsa_contribution > 0:
+                tax_savings = fhsa_contribution * marginal
+                recommendations.append(AccountRecommendation(
+                    rank=rank,
+                    account_type="FHSA",
+                    annual_amount=fhsa_contribution,
+                    annual_limit=fhsa_limit,
+                    tax_benefit="pre-tax + tax-free withdrawal",
+                    tax_savings_estimate=tax_savings,
+                    reason=(
+                        "FHSA combines RRSP deductibility with TFSA-style tax-free "
+                        "withdrawal for a first home. Best of both worlds — use it fully "
+                        f"to build toward your home purchase goal."
+                    ),
+                    action=f"Open and contribute ${fhsa_contribution:,.0f} to your FHSA "
+                           f"(annual room: ${fhsa_limit:,.0f}, lifetime: $40,000).",
+                    priority="essential",
+                ))
+                remaining -= fhsa_contribution
+                rank += 1
+
+        # Non-registered (remaining)
+        if remaining > 0:
+            recommendations.append(AccountRecommendation(
+                rank=rank,
+                account_type="Non-Registered",
+                annual_amount=remaining,
+                annual_limit=remaining,
+                tax_benefit="taxable",
+                tax_savings_estimate=Decimal("0"),
+                reason=(
+                    "After maxing registered accounts, non-registered investing "
+                    "provides flexibility. Prioritize tax-efficient ETFs to minimize "
+                    "annual distributions."
+                ),
+                action=f"Invest remaining ${remaining:,.0f} in a non-registered account. "
+                       "Use broad-market ETFs with low turnover.",
+                priority="low",
+            ))
+            remaining = Decimal("0")
+            rank += 1
+
+        # Cross-border alerts
+        if AdvisorGoal.RELOCATION_US in goals:
+            cross_border_alerts.append(
+                "Planning to relocate to the US: RRSP can be kept and remains "
+                "tax-deferred in the US under the US-CA tax treaty (Article XVIII). "
+                "TFSA gains become taxable in the US — consider strategic withdrawals "
+                "before departure or consult a cross-border CPA."
+            )
+            cross_border_alerts.append(self.tax.cross_border_rrsp_note())
+
+        total_sheltered = sum(
+            r.annual_amount for r in recommendations
+            if r.account_type not in ("Non-Registered",)
+        )
+        total_tax_savings = sum(r.tax_savings_estimate for r in recommendations)
+
+        return OptimizationResult(
+            total_available_to_invest=annual_savings,
+            total_tax_sheltered_capacity=total_sheltered,
+            recommendations=recommendations,
+            unallocated_amount=remaining,
+            total_estimated_tax_savings=total_tax_savings,
+            summary=self._ca_summary(recommendations, annual_savings, marginal),
+            cross_border_alerts=cross_border_alerts,
+        )
+
+    def _optimize_usa(
+        self,
+        income, annual_savings, employment_type, visa_type, goals,
+        age, year, tax_result, limits, state
+    ) -> OptimizationResult:
+        recommendations = []
+        remaining = annual_savings
+        rank = 1
+        marginal = tax_result.marginal_rate
+        cross_border_alerts = []
+
+        k401_limit = limits.k401_limit or Decimal("0")
+        ira_limit = limits.ira_limit or Decimal("0")
+
+        # Roth IRA income phase-out check (simplified: < $161k single, < $240k MFJ)
+        roth_eligible = income < Decimal("161000")
+
+        # 1. 401(k) — primary pre-tax vehicle for employees
+        if employment_type in (EmploymentType.EMPLOYEE.value, "employee"):
+            k401_contribution = min(remaining, k401_limit)
+            if k401_contribution > 0:
+                tax_savings = k401_contribution * marginal
+                recommendations.append(AccountRecommendation(
+                    rank=rank,
+                    account_type="401(k)",
+                    annual_amount=k401_contribution,
+                    annual_limit=k401_limit,
+                    tax_benefit="pre-tax",
+                    tax_savings_estimate=tax_savings,
+                    reason=(
+                        f"401(k) contributions reduce your taxable income at your "
+                        f"{float(marginal*100):.1f}% marginal rate. "
+                        "Many employers match — always capture the full match first."
+                    ),
+                    action=f"Contribute ${k401_contribution:,.0f} to your 401(k) "
+                           f"(2025 limit: ${k401_limit:,.0f}). "
+                           "Ensure you capture any employer match.",
+                    priority="essential",
+                ))
+                remaining -= k401_contribution
+                rank += 1
+        elif employment_type in (EmploymentType.SELF_EMPLOYED.value, "self_employed",
+                                  EmploymentType.CONTRACTOR.value, "contractor"):
+            # Solo 401(k) or SEP-IRA for self-employed
+            solo_limit = min(remaining, Decimal("69000"))  # 2025 solo 401k limit
+            if solo_limit > 0:
+                recommendations.append(AccountRecommendation(
+                    rank=rank,
+                    account_type="Solo 401(k) / SEP-IRA",
+                    annual_amount=min(remaining, solo_limit),
+                    annual_limit=solo_limit,
+                    tax_benefit="pre-tax",
+                    tax_savings_estimate=min(remaining, solo_limit) * marginal,
+                    reason=(
+                        "Self-employed workers can shelter significantly more via "
+                        "Solo 401(k) (up to $69,000 for 2025, including employer contribution). "
+                        "SEP-IRA is simpler to administer."
+                    ),
+                    action=f"Open a Solo 401(k) or SEP-IRA. Contribute up to "
+                           f"${min(remaining, solo_limit):,.0f}.",
+                    priority="essential",
+                ))
+                remaining -= min(remaining, solo_limit)
+                rank += 1
+
+        # 2. Roth IRA (if income-eligible)
+        ira_contribution = min(remaining, ira_limit)
+        if ira_contribution > 0:
+            if roth_eligible:
+                recommendations.append(AccountRecommendation(
+                    rank=rank,
+                    account_type="Roth IRA",
+                    annual_amount=ira_contribution,
+                    annual_limit=ira_limit,
+                    tax_benefit="tax-free growth",
+                    tax_savings_estimate=ira_contribution * Decimal("0.15"),
+                    reason=(
+                        "Roth IRA grows and is withdrawn tax-free. "
+                        "Excellent for long-term wealth — especially valuable if you "
+                        "expect higher taxes in retirement."
+                    ),
+                    action=f"Contribute ${ira_contribution:,.0f} to a Roth IRA "
+                           f"(2025 limit: ${ira_limit:,.0f}).",
+                    priority="high",
+                ))
+            else:
+                recommendations.append(AccountRecommendation(
+                    rank=rank,
+                    account_type="Traditional IRA (Backdoor Roth)",
+                    annual_amount=ira_contribution,
+                    annual_limit=ira_limit,
+                    tax_benefit="tax-deferred / backdoor Roth conversion",
+                    tax_savings_estimate=Decimal("0"),
+                    reason=(
+                        "Income too high for direct Roth contribution. "
+                        "Use the backdoor Roth strategy: contribute to non-deductible "
+                        "Traditional IRA, then immediately convert to Roth."
+                    ),
+                    action=f"Execute backdoor Roth: contribute ${ira_contribution:,.0f} "
+                           "to Traditional IRA (after-tax), then convert to Roth.",
+                    priority="high",
+                ))
+            remaining -= ira_contribution
+            rank += 1
+
+        # 3. HSA if applicable (assume high-deductible health plan)
+        hsa_limit = limits.hsa_individual or Decimal("4300")
+        hsa_contribution = min(remaining, hsa_limit)
+        if hsa_contribution > 0:
+            recommendations.append(AccountRecommendation(
+                rank=rank,
+                account_type="HSA",
+                annual_amount=hsa_contribution,
+                annual_limit=hsa_limit,
+                tax_benefit="triple tax-advantaged",
+                tax_savings_estimate=hsa_contribution * marginal,
+                reason=(
+                    "HSA is the only triple tax-advantaged account: "
+                    "contributions pre-tax, growth tax-free, withdrawals tax-free for medical. "
+                    "After 65 you can withdraw for any purpose (like a Traditional IRA)."
+                ),
+                action=f"If on a HDHP, contribute ${hsa_contribution:,.0f} to your HSA.",
+                priority="medium",
+            ))
+            remaining -= hsa_contribution
+            rank += 1
+
+        # 4. Taxable brokerage
+        if remaining > 0:
+            recommendations.append(AccountRecommendation(
+                rank=rank,
+                account_type="Taxable Brokerage",
+                annual_amount=remaining,
+                annual_limit=remaining,
+                tax_benefit="taxable",
+                tax_savings_estimate=Decimal("0"),
+                reason=(
+                    "After maxing tax-advantaged accounts, invest in a taxable brokerage. "
+                    "Long-term capital gains rates are favorable (0–20%)."
+                ),
+                action=f"Invest remaining ${remaining:,.0f} in low-turnover, "
+                       "tax-efficient index ETFs (VTI, VXUS).",
+                priority="low",
+            ))
+            remaining = Decimal("0")
+            rank += 1
+
+        # Cross-border alerts for US residents with CA goals
+        if AdvisorGoal.RELOCATION_CA in goals:
+            cross_border_alerts.append(self.tax.roth_relocation_note())
+            cross_border_alerts.append(
+                "Maximize Roth IRA before relocating to Canada. "
+                "Roth gains after becoming a Canadian resident may be taxable in Canada "
+                "unless treaty elections are made annually (RC268)."
+            )
+
+        total_sheltered = sum(
+            r.annual_amount for r in recommendations
+            if r.account_type not in ("Taxable Brokerage",)
+        )
+        total_tax_savings = sum(r.tax_savings_estimate for r in recommendations)
+
+        return OptimizationResult(
+            total_available_to_invest=annual_savings,
+            total_tax_sheltered_capacity=total_sheltered,
+            recommendations=recommendations,
+            unallocated_amount=remaining,
+            total_estimated_tax_savings=total_tax_savings,
+            summary=self._us_summary(recommendations, annual_savings, marginal),
+            cross_border_alerts=cross_border_alerts,
+        )
+
+    def _optimize_generic(self, annual_savings: Decimal) -> OptimizationResult:
+        return OptimizationResult(
+            total_available_to_invest=annual_savings,
+            total_tax_sheltered_capacity=Decimal("0"),
+            recommendations=[
+                AccountRecommendation(
+                    rank=1,
+                    account_type="General Investment Account",
+                    annual_amount=annual_savings,
+                    annual_limit=annual_savings,
+                    tax_benefit="taxable",
+                    tax_savings_estimate=Decimal("0"),
+                    reason="No country-specific rules available. Invest in low-cost index funds.",
+                    action="Invest in broadly diversified, low-cost index ETFs.",
+                    priority="medium",
+                )
+            ],
+            summary="Generic investment recommendation (no country-specific tax rules).",
+        )
+
+    def _ca_summary(
+        self,
+        recs: list[AccountRecommendation],
+        total: Decimal,
+        marginal: Decimal,
+    ) -> str:
+        sheltered = sum(r.annual_amount for r in recs if r.account_type != "Non-Registered")
+        pct = (sheltered / total * 100) if total > 0 else Decimal("0")
+        types = [r.account_type for r in recs if r.account_type != "Non-Registered"]
+        return (
+            f"${sheltered:,.0f} ({float(pct):.0f}%) of your annual savings can be sheltered "
+            f"in tax-advantaged accounts ({', '.join(types)}). "
+            f"At your {float(marginal*100):.1f}% marginal rate, this approach saves "
+            f"approximately ${sum(r.tax_savings_estimate for r in recs):,.0f}/year in taxes."
+        )
+
+    def _us_summary(
+        self,
+        recs: list[AccountRecommendation],
+        total: Decimal,
+        marginal: Decimal,
+    ) -> str:
+        sheltered = sum(r.annual_amount for r in recs if r.account_type != "Taxable Brokerage")
+        pct = (sheltered / total * 100) if total > 0 else Decimal("0")
+        types = [r.account_type for r in recs if r.account_type != "Taxable Brokerage"]
+        return (
+            f"${sheltered:,.0f} ({float(pct):.0f}%) of your annual savings can be sheltered "
+            f"via {', '.join(types)}. "
+            f"Estimated annual tax savings: ${sum(r.tax_savings_estimate for r in recs):,.0f}."
+        )

--- a/backend/services/tax_rules_engine.py
+++ b/backend/services/tax_rules_engine.py
@@ -1,0 +1,572 @@
+"""Tax Rules Engine for the Neural Economic Growth Advisor.
+
+Canopy - Personal Finance Platform
+
+Hardcoded, versioned tax data for Canada and USA (2025/2026).
+No external API calls — all data is embedded and auditable.
+
+Covers:
+- Federal + provincial/state income tax brackets
+- Registered account contribution limits (RRSP, TFSA, FHSA, 401k, IRA)
+- Capital gains tax rates
+- Cross-border treaty considerations (US-CA Article XVIII)
+
+IMPORTANT: This is for planning purposes only, not tax advice.
+Tax laws change annually. Verify with a tax professional.
+"""
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TaxBracket:
+    """A single marginal tax bracket."""
+    min_income: Decimal
+    max_income: Optional[Decimal]  # None = no upper bound
+    rate: Decimal                  # e.g. Decimal("0.205") for 20.5%
+
+
+@dataclass
+class TaxResult:
+    """Result of a tax calculation."""
+    tax_owed: Decimal
+    effective_rate: Decimal         # tax_owed / gross_income
+    marginal_rate: Decimal          # rate of the top bracket reached
+    federal_tax: Decimal
+    provincial_state_tax: Decimal
+    total_deductions: Decimal       # e.g. basic personal amounts deducted
+    net_income: Decimal             # gross - tax_owed
+
+
+@dataclass
+class ContributionLimits:
+    """Annual contribution room for registered accounts."""
+    year: int
+    country: str
+
+    # Canada
+    rrsp_limit: Optional[Decimal] = None          # Lower of 18% of income OR dollar limit
+    rrsp_dollar_cap: Optional[Decimal] = None     # Annual dollar cap
+    tfsa_limit: Optional[Decimal] = None          # Annual TFSA room
+    fhsa_limit: Optional[Decimal] = None          # Annual FHSA room
+    fhsa_lifetime: Optional[Decimal] = None       # FHSA lifetime limit
+
+    # USA
+    k401_limit: Optional[Decimal] = None          # 401(k) elective deferral
+    k401_catch_up: Optional[Decimal] = None       # Extra if age >= 50
+    ira_limit: Optional[Decimal] = None           # IRA / Roth IRA combined
+    ira_catch_up: Optional[Decimal] = None        # Extra if age >= 50
+    hsa_individual: Optional[Decimal] = None      # HSA (individual plan)
+    hsa_family: Optional[Decimal] = None          # HSA (family plan)
+
+
+@dataclass
+class CapitalGainsTaxResult:
+    """Result of a capital gains tax calculation."""
+    gross_gains: Decimal
+    taxable_gains: Decimal           # After inclusion rate / exclusions
+    tax_owed: Decimal
+    effective_rate: Decimal          # tax_owed / gross_gains
+    inclusion_rate: Decimal          # Fraction of gains that is taxable (CA)
+    long_term_rate: Optional[Decimal] = None   # US LTCG rate applied
+
+
+# ---------------------------------------------------------------------------
+# Tax data tables (2025 values; add 2026 when CRA/IRS publish)
+# ---------------------------------------------------------------------------
+
+# Canada — Federal brackets 2025
+CA_FEDERAL_BRACKETS_2025: list[TaxBracket] = [
+    TaxBracket(Decimal("0"),       Decimal("57375"),  Decimal("0.15")),
+    TaxBracket(Decimal("57375"),   Decimal("114750"), Decimal("0.205")),
+    TaxBracket(Decimal("114750"),  Decimal("177882"), Decimal("0.26")),
+    TaxBracket(Decimal("177882"),  Decimal("253414"), Decimal("0.29")),
+    TaxBracket(Decimal("253414"),  None,              Decimal("0.33")),
+]
+
+CA_FEDERAL_BASIC_PERSONAL_2025 = Decimal("16129")   # Basic personal amount
+
+# Canada — Ontario provincial brackets 2025
+CA_ON_BRACKETS_2025: list[TaxBracket] = [
+    TaxBracket(Decimal("0"),       Decimal("51446"),  Decimal("0.0505")),
+    TaxBracket(Decimal("51446"),   Decimal("102894"), Decimal("0.0915")),
+    TaxBracket(Decimal("102894"),  Decimal("150000"), Decimal("0.1116")),
+    TaxBracket(Decimal("150000"),  Decimal("220000"), Decimal("0.1216")),
+    TaxBracket(Decimal("220000"),  None,              Decimal("0.1316")),
+]
+CA_ON_BASIC_PERSONAL_2025 = Decimal("11865")
+
+# Canada — British Columbia provincial brackets 2025
+CA_BC_BRACKETS_2025: list[TaxBracket] = [
+    TaxBracket(Decimal("0"),       Decimal("45654"),  Decimal("0.0506")),
+    TaxBracket(Decimal("45654"),   Decimal("91310"),  Decimal("0.077")),
+    TaxBracket(Decimal("91310"),   Decimal("104835"), Decimal("0.105")),
+    TaxBracket(Decimal("104835"),  Decimal("127299"), Decimal("0.1229")),
+    TaxBracket(Decimal("127299"),  Decimal("172602"), Decimal("0.147")),
+    TaxBracket(Decimal("172602"),  Decimal("240716"), Decimal("0.168")),
+    TaxBracket(Decimal("240716"),  None,              Decimal("0.205")),
+]
+CA_BC_BASIC_PERSONAL_2025 = Decimal("11981")
+
+# Canada — Alberta provincial brackets 2025
+CA_AB_BRACKETS_2025: list[TaxBracket] = [
+    TaxBracket(Decimal("0"),       Decimal("148269"), Decimal("0.10")),
+    TaxBracket(Decimal("148269"),  Decimal("177922"), Decimal("0.12")),
+    TaxBracket(Decimal("177922"),  Decimal("237230"), Decimal("0.13")),
+    TaxBracket(Decimal("237230"),  Decimal("355845"), Decimal("0.14")),
+    TaxBracket(Decimal("355845"),  None,              Decimal("0.15")),
+]
+CA_AB_BASIC_PERSONAL_2025 = Decimal("21003")
+
+# USA — Federal brackets 2025 (single filer)
+US_FEDERAL_BRACKETS_2025_SINGLE: list[TaxBracket] = [
+    TaxBracket(Decimal("0"),       Decimal("11925"),  Decimal("0.10")),
+    TaxBracket(Decimal("11925"),   Decimal("48475"),  Decimal("0.12")),
+    TaxBracket(Decimal("48475"),   Decimal("103350"), Decimal("0.22")),
+    TaxBracket(Decimal("103350"),  Decimal("197300"), Decimal("0.24")),
+    TaxBracket(Decimal("197300"),  Decimal("250525"), Decimal("0.32")),
+    TaxBracket(Decimal("250525"),  Decimal("626350"), Decimal("0.35")),
+    TaxBracket(Decimal("626350"),  None,              Decimal("0.37")),
+]
+
+# USA — Federal brackets 2025 (married filing jointly)
+US_FEDERAL_BRACKETS_2025_MFJ: list[TaxBracket] = [
+    TaxBracket(Decimal("0"),       Decimal("23850"),  Decimal("0.10")),
+    TaxBracket(Decimal("23850"),   Decimal("96950"),  Decimal("0.12")),
+    TaxBracket(Decimal("96950"),   Decimal("206700"), Decimal("0.22")),
+    TaxBracket(Decimal("206700"),  Decimal("394600"), Decimal("0.24")),
+    TaxBracket(Decimal("394600"),  Decimal("501050"), Decimal("0.32")),
+    TaxBracket(Decimal("501050"),  Decimal("751600"), Decimal("0.35")),
+    TaxBracket(Decimal("751600"),  None,              Decimal("0.37")),
+]
+
+US_STANDARD_DEDUCTION_SINGLE_2025 = Decimal("15000")
+US_STANDARD_DEDUCTION_MFJ_2025    = Decimal("30000")
+
+# USA — State income tax (simplified flat/top rate for planning)
+# A full bracket table per state is beyond scope; use effective planning rate.
+US_STATE_TAX_RATES: dict[str, Decimal] = {
+    "CA": Decimal("0.093"),   # California top marginal (simplified)
+    "NY": Decimal("0.0685"),  # New York
+    "TX": Decimal("0.00"),    # Texas (no income tax)
+    "FL": Decimal("0.00"),    # Florida (no income tax)
+    "WA": Decimal("0.00"),    # Washington (no income tax)
+    "OR": Decimal("0.099"),   # Oregon
+    "WI": Decimal("0.0765"),  # Wisconsin
+    "IL": Decimal("0.0495"),  # Illinois (flat)
+    "MA": Decimal("0.05"),    # Massachusetts (flat)
+    "CO": Decimal("0.044"),   # Colorado (flat)
+}
+
+# Contribution limits
+CA_CONTRIBUTION_LIMITS: dict[int, ContributionLimits] = {
+    2025: ContributionLimits(
+        year=2025,
+        country="CA",
+        rrsp_dollar_cap=Decimal("32490"),
+        tfsa_limit=Decimal("7000"),
+        fhsa_limit=Decimal("8000"),
+        fhsa_lifetime=Decimal("40000"),
+    ),
+    2026: ContributionLimits(
+        year=2026,
+        country="CA",
+        rrsp_dollar_cap=Decimal("32490"),   # Updated when CRA publishes
+        tfsa_limit=Decimal("7000"),
+        fhsa_limit=Decimal("8000"),
+        fhsa_lifetime=Decimal("40000"),
+    ),
+}
+
+US_CONTRIBUTION_LIMITS: dict[int, ContributionLimits] = {
+    2025: ContributionLimits(
+        year=2025,
+        country="US",
+        k401_limit=Decimal("23500"),
+        k401_catch_up=Decimal("7500"),
+        ira_limit=Decimal("7000"),
+        ira_catch_up=Decimal("1000"),
+        hsa_individual=Decimal("4300"),
+        hsa_family=Decimal("8550"),
+    ),
+    2026: ContributionLimits(
+        year=2026,
+        country="US",
+        k401_limit=Decimal("24000"),       # Estimated; updated when IRS publishes
+        k401_catch_up=Decimal("7500"),
+        ira_limit=Decimal("7000"),
+        ira_catch_up=Decimal("1000"),
+        hsa_individual=Decimal("4400"),
+        hsa_family=Decimal("8750"),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Province/State bracket lookup
+# ---------------------------------------------------------------------------
+
+_CA_PROVINCE_BRACKETS: dict[str, list[TaxBracket]] = {
+    "ON": CA_ON_BRACKETS_2025,
+    "BC": CA_BC_BRACKETS_2025,
+    "AB": CA_AB_BRACKETS_2025,
+}
+
+_CA_PROVINCE_BASIC_PERSONAL: dict[str, Decimal] = {
+    "ON": CA_ON_BASIC_PERSONAL_2025,
+    "BC": CA_BC_BASIC_PERSONAL_2025,
+    "AB": CA_AB_BASIC_PERSONAL_2025,
+}
+
+
+# ---------------------------------------------------------------------------
+# Core engine
+# ---------------------------------------------------------------------------
+
+class TaxRulesEngine:
+    """Hardcoded tax rules for Canada and USA.
+
+    All monetary values are in the local currency of the country
+    (CAD for Canada, USD for USA).
+    """
+
+    # US-CA treaty: 15% withholding on dividends paid to non-residents
+    US_CA_DIVIDEND_WITHHOLDING = Decimal("0.15")
+
+    # Canada capital gains inclusion rates (post-June 2024 budget)
+    CA_CAPITAL_GAINS_INCLUSION_BELOW = Decimal("0.50")    # First $250k
+    CA_CAPITAL_GAINS_INCLUSION_ABOVE = Decimal("0.6667")  # Above $250k
+    CA_CAPITAL_GAINS_THRESHOLD = Decimal("250000")
+
+    def _apply_brackets(
+        self,
+        taxable_income: Decimal,
+        brackets: list[TaxBracket],
+    ) -> tuple[Decimal, Decimal]:
+        """Apply progressive bracket tax. Returns (tax_owed, marginal_rate)."""
+        tax = Decimal("0")
+        marginal = Decimal("0")
+
+        for bracket in brackets:
+            if taxable_income <= 0:
+                break
+            if bracket.max_income is None:
+                slab = taxable_income
+            else:
+                slab = min(taxable_income, bracket.max_income - bracket.min_income)
+            tax += slab * bracket.rate
+            marginal = bracket.rate
+            taxable_income -= slab
+
+        return tax, marginal
+
+    def calculate_tax(
+        self,
+        country: str,
+        province_or_state: Optional[str],
+        gross_income: Decimal,
+        year: int = 2025,
+        filing_status: str = "single",
+    ) -> TaxResult:
+        """Calculate combined income tax for a given country/jurisdiction.
+
+        Args:
+            country: "CA" or "US"
+            province_or_state: Province (ON, BC, AB) or US state code
+            gross_income: Annual gross income in local currency
+            year: Tax year
+            filing_status: "single" or "mfj" (married filing jointly, US only)
+        """
+        if country == "CA":
+            return self._calculate_canada_tax(
+                gross_income, province_or_state, year
+            )
+        elif country == "US":
+            return self._calculate_us_tax(
+                gross_income, province_or_state, year, filing_status
+            )
+        else:
+            # Generic fallback: estimate 25% effective rate
+            estimated_tax = gross_income * Decimal("0.25")
+            return TaxResult(
+                tax_owed=estimated_tax,
+                effective_rate=Decimal("0.25"),
+                marginal_rate=Decimal("0.25"),
+                federal_tax=estimated_tax,
+                provincial_state_tax=Decimal("0"),
+                total_deductions=Decimal("0"),
+                net_income=gross_income - estimated_tax,
+            )
+
+    def _calculate_canada_tax(
+        self,
+        gross_income: Decimal,
+        province: Optional[str],
+        year: int,
+    ) -> TaxResult:
+        # Basic personal amount reduces taxable income
+        bpa_federal = CA_FEDERAL_BASIC_PERSONAL_2025
+        federal_taxable = max(Decimal("0"), gross_income - bpa_federal)
+
+        federal_tax, fed_marginal = self._apply_brackets(
+            federal_taxable, CA_FEDERAL_BRACKETS_2025
+        )
+        # BPA credit: bpa * 15% (lowest federal rate)
+        federal_tax = max(Decimal("0"), federal_tax - bpa_federal * Decimal("0.15"))
+
+        # Provincial tax
+        prov = (province or "ON").upper()
+        prov_brackets = _CA_PROVINCE_BRACKETS.get(prov, CA_ON_BRACKETS_2025)
+        prov_bpa = _CA_PROVINCE_BASIC_PERSONAL.get(prov, CA_ON_BASIC_PERSONAL_2025)
+        prov_taxable = max(Decimal("0"), gross_income - prov_bpa)
+        prov_tax, prov_marginal = self._apply_brackets(prov_taxable, prov_brackets)
+        prov_rate = prov_brackets[0].rate if prov_brackets else Decimal("0.0505")
+        prov_tax = max(Decimal("0"), prov_tax - prov_bpa * prov_rate)
+
+        total_tax = federal_tax + prov_tax
+        effective = (total_tax / gross_income) if gross_income > 0 else Decimal("0")
+        combined_marginal = fed_marginal + prov_marginal
+
+        return TaxResult(
+            tax_owed=total_tax,
+            effective_rate=effective,
+            marginal_rate=combined_marginal,
+            federal_tax=federal_tax,
+            provincial_state_tax=prov_tax,
+            total_deductions=bpa_federal + prov_bpa,
+            net_income=gross_income - total_tax,
+        )
+
+    def _calculate_us_tax(
+        self,
+        gross_income: Decimal,
+        state: Optional[str],
+        year: int,
+        filing_status: str,
+    ) -> TaxResult:
+        # Standard deduction
+        if filing_status == "mfj":
+            std_ded = US_STANDARD_DEDUCTION_MFJ_2025
+            brackets = US_FEDERAL_BRACKETS_2025_MFJ
+        else:
+            std_ded = US_STANDARD_DEDUCTION_SINGLE_2025
+            brackets = US_FEDERAL_BRACKETS_2025_SINGLE
+
+        federal_taxable = max(Decimal("0"), gross_income - std_ded)
+        federal_tax, fed_marginal = self._apply_brackets(federal_taxable, brackets)
+
+        # State tax (simplified flat/top rate for planning)
+        st = (state or "").upper()
+        state_rate = US_STATE_TAX_RATES.get(st, Decimal("0.05"))
+        state_tax = gross_income * state_rate
+
+        total_tax = federal_tax + state_tax
+        effective = (total_tax / gross_income) if gross_income > 0 else Decimal("0")
+
+        return TaxResult(
+            tax_owed=total_tax,
+            effective_rate=effective,
+            marginal_rate=fed_marginal + state_rate,
+            federal_tax=federal_tax,
+            provincial_state_tax=state_tax,
+            total_deductions=std_ded,
+            net_income=gross_income - total_tax,
+        )
+
+    def get_contribution_limits(
+        self,
+        country: str,
+        year: int = 2025,
+        annual_earned_income: Optional[Decimal] = None,
+        age: Optional[int] = None,
+    ) -> ContributionLimits:
+        """Get registered account contribution limits for a given year.
+
+        For Canada, RRSP limit = min(18% of previous year income, dollar cap).
+        RRSP room is also affected by pension adjustments (ignored here).
+        """
+        if country == "CA":
+            limits = CA_CONTRIBUTION_LIMITS.get(year, CA_CONTRIBUTION_LIMITS[2025])
+            # Calculate RRSP limit based on income
+            if annual_earned_income and annual_earned_income > 0:
+                income_based = annual_earned_income * Decimal("0.18")
+                limits.rrsp_limit = min(income_based, limits.rrsp_dollar_cap)
+            else:
+                limits.rrsp_limit = limits.rrsp_dollar_cap
+            return limits
+
+        elif country == "US":
+            limits = US_CONTRIBUTION_LIMITS.get(year, US_CONTRIBUTION_LIMITS[2025])
+            # Catch-up contributions for age 50+
+            if age and age >= 50:
+                limits.k401_limit = (limits.k401_limit or Decimal("0")) + (limits.k401_catch_up or Decimal("0"))
+                limits.ira_limit = (limits.ira_limit or Decimal("0")) + (limits.ira_catch_up or Decimal("0"))
+            return limits
+
+        # Generic empty limits
+        return ContributionLimits(year=year, country=country)
+
+    def calculate_capital_gains_tax(
+        self,
+        country: str,
+        province_or_state: Optional[str],
+        gross_gains: Decimal,
+        other_income: Decimal = Decimal("0"),
+        year: int = 2025,
+        long_term: bool = True,
+    ) -> CapitalGainsTaxResult:
+        """Calculate capital gains tax.
+
+        Canada: inclusion rate applied, then taxed as regular income.
+        USA: separate long-term / short-term rates.
+        """
+        if country == "CA":
+            return self._canada_capital_gains(
+                gross_gains, other_income, province_or_state, year
+            )
+        elif country == "US":
+            return self._us_capital_gains(
+                gross_gains, other_income, province_or_state, year, long_term
+            )
+        else:
+            estimated = gross_gains * Decimal("0.20")
+            return CapitalGainsTaxResult(
+                gross_gains=gross_gains,
+                taxable_gains=gross_gains,
+                tax_owed=estimated,
+                effective_rate=Decimal("0.20"),
+                inclusion_rate=Decimal("1.0"),
+            )
+
+    def _canada_capital_gains(
+        self,
+        gross_gains: Decimal,
+        other_income: Decimal,
+        province: Optional[str],
+        year: int,
+    ) -> CapitalGainsTaxResult:
+        # Post-June 2024 budget: 50% inclusion for first $250k, 66.67% above
+        if gross_gains <= self.CA_CAPITAL_GAINS_THRESHOLD:
+            taxable = gross_gains * self.CA_CAPITAL_GAINS_INCLUSION_BELOW
+            inclusion = self.CA_CAPITAL_GAINS_INCLUSION_BELOW
+        else:
+            below_threshold = self.CA_CAPITAL_GAINS_THRESHOLD * self.CA_CAPITAL_GAINS_INCLUSION_BELOW
+            above_threshold = (gross_gains - self.CA_CAPITAL_GAINS_THRESHOLD) * self.CA_CAPITAL_GAINS_INCLUSION_ABOVE
+            taxable = below_threshold + above_threshold
+            inclusion = taxable / gross_gains
+
+        # Tax the included gains as income on top of other_income
+        total_income = other_income + taxable
+        full_result = self._calculate_canada_tax(total_income, province, year)
+        base_result = self._calculate_canada_tax(other_income, province, year)
+        tax_on_gains = full_result.tax_owed - base_result.tax_owed
+        effective = (tax_on_gains / gross_gains) if gross_gains > 0 else Decimal("0")
+
+        return CapitalGainsTaxResult(
+            gross_gains=gross_gains,
+            taxable_gains=taxable,
+            tax_owed=tax_on_gains,
+            effective_rate=effective,
+            inclusion_rate=inclusion,
+        )
+
+    def _us_capital_gains(
+        self,
+        gross_gains: Decimal,
+        other_income: Decimal,
+        state: Optional[str],
+        year: int,
+        long_term: bool,
+    ) -> CapitalGainsTaxResult:
+        total_income = other_income + gross_gains
+
+        if not long_term:
+            # Short-term: taxed as ordinary income
+            result = self._calculate_us_tax(total_income, state, year, "single")
+            base = self._calculate_us_tax(other_income, state, year, "single")
+            tax_on_gains = result.tax_owed - base.tax_owed
+            return CapitalGainsTaxResult(
+                gross_gains=gross_gains,
+                taxable_gains=gross_gains,
+                tax_owed=tax_on_gains,
+                effective_rate=(tax_on_gains / gross_gains) if gross_gains > 0 else Decimal("0"),
+                inclusion_rate=Decimal("1.0"),
+                long_term_rate=None,
+            )
+
+        # Long-term federal LTCG rates (2025)
+        if total_income <= Decimal("48350"):
+            ltcg_rate = Decimal("0.00")
+        elif total_income <= Decimal("533400"):
+            ltcg_rate = Decimal("0.15")
+        else:
+            ltcg_rate = Decimal("0.20")
+
+        federal_gains_tax = gross_gains * ltcg_rate
+
+        # Net Investment Income Tax (NIIT) 3.8% over $200k
+        if total_income > Decimal("200000"):
+            niit = gross_gains * Decimal("0.038")
+        else:
+            niit = Decimal("0")
+
+        # State tax still applies to LTCG for most states
+        st = (state or "").upper()
+        state_rate = US_STATE_TAX_RATES.get(st, Decimal("0.05"))
+        state_gains_tax = gross_gains * state_rate
+
+        total_tax = federal_gains_tax + niit + state_gains_tax
+        effective = (total_tax / gross_gains) if gross_gains > 0 else Decimal("0")
+
+        return CapitalGainsTaxResult(
+            gross_gains=gross_gains,
+            taxable_gains=gross_gains,
+            tax_owed=total_tax,
+            effective_rate=effective,
+            inclusion_rate=Decimal("1.0"),
+            long_term_rate=ltcg_rate,
+        )
+
+    def estimate_tax_drag(
+        self,
+        country: str,
+        province_or_state: Optional[str],
+        annual_gains: Decimal,
+        annual_income: Decimal,
+        year: int = 2025,
+    ) -> Decimal:
+        """Estimate annual tax drag on investment growth (as a fraction).
+
+        Used by the Growth Advisor to model after-tax compounding.
+        Returns the fraction of gains consumed by tax (e.g. 0.15 = 15%).
+        """
+        if annual_gains <= 0:
+            return Decimal("0")
+        result = self.calculate_capital_gains_tax(
+            country, province_or_state, annual_gains, annual_income, year
+        )
+        return result.effective_rate
+
+    def cross_border_rrsp_note(self) -> str:
+        """Return the key US-CA treaty note on RRSP treatment."""
+        return (
+            "Under Article XVIII(7) of the US-Canada Tax Treaty, "
+            "RRSP growth is generally not taxable in the US until withdrawn. "
+            "An election (Form 8891 / simplified via Form 1040) is required. "
+            "Consult a cross-border tax professional."
+        )
+
+    def roth_relocation_note(self) -> str:
+        """Return the note on Roth IRA when relocating from US to Canada."""
+        return (
+            "Roth IRA is not recognized as a tax-free account under Canadian tax law. "
+            "Growth inside a Roth IRA is taxable in Canada unless a treaty election "
+            "is made annually (RC268). Maximize Roth contributions before relocating "
+            "to Canada to lock in US tax-free growth. Consult a cross-border CPA."
+        )


### PR DESCRIPTION
Preserved on its own branch so the feat/portfolio-review-pivot worktree is clean while keeping the work recoverable.

Contents:
- db/models/financial_profile.py: user's financial situation, goals, and preferences (stored at a single row per user; JSONB-heavy).
- services/tax_rules_engine.py: versioned CA/US tax data for 2025/2026.
- services/account_optimizer.py: given a profile + existing assets, suggests account-level allocation adjustments.
- alembic/versions/20260219_0004_add_financial_profile.py: creates financial_profiles table.

Known issue: _0004's down_revision collides with _0005 on this branch (both descend from 20260201_0003). Before resuming, reparent _0004 to come after _0007 so the chain is 0003 -> 0005 -> 0006 -> 0007 -> 0004.

Made-with: Cursor