### PR TITLE
feat: Amex monthly CA CSV, Wealthsimple row kinds, Questrade env + nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Pre-release **0.x**; **1.0.0** when feature-complete.
 
 ## [0.10.4] - 2026-04-19
 
+- **Transactions page:** list/create/delete now call **`NEXT_PUBLIC_API_URL`** (same as Accounts / imports), so Monarch- and Wise-imported rows appear instead of failing silently when the frontend and API run on different origins.
 - **Navigation:** **Transactions** promoted to primary sidebar (after Accounts) and added to mobile bottom bar (**Txns**); removed the old collapsed **Advanced** section that hid it.
 
 ## [0.10.3] - 2026-04-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ Notable releases only — **details belong in commits / PRs**, not here.
 
 Pre-release **0.x**; **1.0.0** when feature-complete.
 
+## [0.10.4] - 2026-04-19
+
+- **Navigation:** **Transactions** promoted to primary sidebar (after Accounts) and added to mobile bottom bar (**Txns**); removed the old collapsed **Advanced** section that hid it.
+
 ## [0.10.3] - 2026-04-19
 
-- **CSV import:** Amex Canada **Year-End Summary** preset (`Charges $` / `Credits $`, DD/MM/YYYY); detection when using Generic CSV; Import page option **Amex Year-End Summary (CA)**; Monarch default no longer mis-maps that file when headers match.
+- **Integrations:** Questrade accepts **`QUESTRADE_REFRESH_TOKEN`** from the environment when the request body omits a token (same pattern as **`WISE_API_TOKEN`**), so Vault / External Secrets can inject broker tokens without storing them in the browser. **`GET /v1/integrations/questrade/status`** mirrors Wise; Settings → Integrations lets you Connect / Sync with an empty field when the API has that env var.
+- **Wealthsimple:** map Shape-A transaction codes **SPEND** (cash-account debit) and **TRFINTF** (registered transfer in) so monthly statements do not surface unknown-code warnings.
+- **CSV import:** Amex Canada **Year-End Summary** preset (`Charges $` / `Credits $`, DD/MM/YYYY); **monthly statement** preset (`Date` / `Amount` / `Account #`, `17 Apr 2026` dates); detection when using Generic CSV; Import options **Amex Year-End Summary (CA)** and **Amex Monthly Statement (CA)**; Monarch default no longer mis-maps those files when headers match.
 - README refresh; FIRE optional CAGR from snapshots; net worth chart (stacked area + debt axis); portfolio dividends + positions split; accounts grouping; nav/import/integrations polish + logos; privacy “hide amounts”; **Cursor** project agent skills under `.cursor/skills/` (repo conventions, stack map, UI/backend/import notes).
 - Wise sync writes prices; insights use balance history; holdings cash rows show display name (hide Monarch internal symbols). Wise balances ignore CSV balance-history rows so snapshots never override API `current_price` with $0.
 - **FX**: If BoC/USDCAD is not cached yet, combined CAD/USD views use a **1.35 display fallback** (backend + portfolio) so balances do not all show as $0; rate is still flagged stale when approximate.

--- a/CSV_IMPORT_GUIDE.md
+++ b/CSV_IMPORT_GUIDE.md
@@ -50,6 +50,13 @@ Export from the Amex website **Year-End Summary** (not the regular activity CSV)
 - **Date Format:** DD/MM/YYYY
 - **Default currency:** Choose **CAD** on the Import page when previewing.
 
+### American Express monthly statement (Canada)
+Regular **monthly** exports from Amex Canada (e.g. `jan-2026.csv`) use a different layout than Year-End: one **Amount** column (positive charges, negative credits/refunds), **Date Processed**, **Card Member**, **Account #**, **Merchant**, etc. Dates look like `17 Apr 2026`.
+
+- **Columns:** Date, Date Processed, Description, Card Member, Account #, Amount, … Merchant, Reference (full export may include multi-line quoted fields; that is normal).
+- **Date Format:** `DD Mon YYYY` (English month abbreviation)
+- **Import page:** Choose **Amex Monthly Statement (CA)** or **Generic CSV** (auto-detect).
+
 ### TD Bank
 - **Columns:** Date, Description, Debit, Credit
 - **Date Format:** MM/DD/YYYY

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,3 +7,7 @@ REDIS_URL=redis://redis:6379/0
 SECRET_KEY=change-me
 ENVIRONMENT=development
 
+# Optional — integrations (Vault / ESO in cluster; never commit real tokens)
+# WISE_API_TOKEN=
+# QUESTRADE_REFRESH_TOKEN=
+

--- a/backend/api/csv_import.py
+++ b/backend/api/csv_import.py
@@ -92,9 +92,10 @@ async def preview_csv_import(
     except ValueError:
         bank_format_enum = BankFormat.GENERIC
 
-    # Prefer Amex Year-End when headers match (Import UI may default to Monarch).
+    # Prefer Amex presets when headers match (Import UI may default to Monarch).
     if (
-        detected_format == BankFormat.AMEX_YEAR_END_SUMMARY
+        detected_format
+        in (BankFormat.AMEX_YEAR_END_SUMMARY, BankFormat.AMEX_MONTHLY_STATEMENT_CA)
         and detected_format in csv_service.BANK_FORMATS
         and bank_format_enum == BankFormat.MONARCH
     ):

--- a/backend/api/integrations.py
+++ b/backend/api/integrations.py
@@ -279,9 +279,14 @@ async def sync_wise_to_canopy(request: WiseSyncRequest, db: DbSession):
 
 
 class QuestradeConnectRequest(BaseModel):
-    """Request to connect Questrade (manual authorization token from API Centre)."""
+    """Request to connect Questrade (manual authorization token from API Centre).
 
-    refresh_token: str
+    If ``refresh_token`` is omitted or empty, the API uses ``QUESTRADE_REFRESH_TOKEN``
+    from the environment (e.g. injected from Vault / External Secrets in cluster).
+    A non-empty body value wins over the environment.
+    """
+
+    refresh_token: Optional[str] = None
 
 
 class QuestradeAccountResponse(BaseModel):
@@ -315,13 +320,37 @@ class QuestradeSyncResponse(BaseModel):
     updated_lots: int = 0
 
 
+@router.get("/questrade/status")
+async def get_questrade_status():
+    """Return whether ``QUESTRADE_REFRESH_TOKEN`` is set (e.g. Vault → External Secrets → pod env)."""
+    settings = get_settings()
+    return {"connected": bool((settings.questrade_refresh_token or "").strip())}
+
+
+def _resolve_questrade_refresh_token(request: QuestradeConnectRequest) -> str:
+    body = (request.refresh_token or "").strip()
+    if body:
+        return body
+    env_token = (get_settings().questrade_refresh_token or "").strip()
+    if env_token:
+        return env_token
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            "No Questrade refresh token. Paste a token in the UI, or set QUESTRADE_REFRESH_TOKEN "
+            "(e.g. from Vault via External Secrets)."
+        ),
+    )
+
+
 @router.post("/questrade/test-connection")
 async def test_questrade_connection(request: QuestradeConnectRequest):
     """Test Questrade API connection with provided refresh token."""
     try:
         from backend.services.questrade_integration import QuestradeIntegrationService
 
-        with QuestradeIntegrationService(request.refresh_token) as qt:
+        token = _resolve_questrade_refresh_token(request)
+        with QuestradeIntegrationService(token) as qt:
             accounts = qt.get_accounts()
             if not accounts:
                 raise HTTPException(status_code=400, detail="No accounts found")
@@ -362,7 +391,8 @@ async def get_questrade_accounts(request: QuestradeConnectRequest):
     try:
         from backend.services.questrade_integration import QuestradeIntegrationService
 
-        with QuestradeIntegrationService(request.refresh_token) as qt:
+        token = _resolve_questrade_refresh_token(request)
+        with QuestradeIntegrationService(token) as qt:
             accounts = qt.get_accounts()
             return [
                 QuestradeAccountResponse(
@@ -388,7 +418,8 @@ async def get_questrade_positions(
     try:
         from backend.services.questrade_integration import QuestradeIntegrationService
 
-        with QuestradeIntegrationService(request.refresh_token) as qt:
+        token = _resolve_questrade_refresh_token(request)
+        with QuestradeIntegrationService(token) as qt:
             positions = qt.get_positions(account_number)
             return [
                 QuestradePositionResponse(
@@ -416,7 +447,8 @@ async def sync_questrade(request: QuestradeConnectRequest, db: DbSession):
     created_lots = 0
     updated_lots = 0
 
-    with QuestradeIntegrationService(request.refresh_token) as qt:
+    token = _resolve_questrade_refresh_token(request)
+    with QuestradeIntegrationService(token) as qt:
         accounts = qt.get_accounts()
 
         for acc in accounts:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,8 +25,9 @@ class Settings(BaseSettings):
     environment: str = "development"
     questrade_refresh_token: Optional[str] = None  # For Celery background sync; use Vault in production
 
-    # Optional integration tokens (can be set via env / Vault; UI can also send token per request)
+    # Optional integration tokens (can be set via env / Vault + ESO; UI can also send per request)
     wise_api_token: Optional[str] = None  # WISE_API_TOKEN
+    questrade_refresh_token: Optional[str] = None  # QUESTRADE_REFRESH_TOKEN
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/backend/models/csv_import.py
+++ b/backend/models/csv_import.py
@@ -32,6 +32,7 @@ class BankFormat(str, Enum):
     CAPITAL_ONE = "capital_one"
     AMEX = "amex"
     AMEX_YEAR_END_SUMMARY = "amex_year_end_summary"
+    AMEX_MONTHLY_STATEMENT_CA = "amex_monthly_statement_ca"
     DISCOVER = "discover"
     SCHWAB = "schwab"
     # Canadian Banks

--- a/backend/services/csv_parser.py
+++ b/backend/services/csv_parser.py
@@ -73,6 +73,16 @@ class CSVParserService:
             account_column="Account Number",
             date_format="%d/%m/%Y",
         ),
+        # Amex Canada monthly activity CSV (website export): "17 Apr 2026", positive Amount = charge
+        BankFormat.AMEX_MONTHLY_STATEMENT_CA: FieldMapping(
+            date_column="Date",
+            description_column="Description",
+            amount_column="Amount",
+            merchant_column="Merchant",
+            account_column="Account #",
+            date_format="%d %b %Y",
+            negative_means_expense=False,
+        ),
         BankFormat.CAPITAL_ONE: FieldMapping(
             date_column="Transaction Date",
             description_column="Description",
@@ -159,6 +169,16 @@ class CSVParserService:
             and any(h == "transaction" for h in headers_lower)
         ):
             return BankFormat.AMEX_YEAR_END_SUMMARY
+
+        # Amex Canada monthly statement export (Date / Description / Amount, Date Processed, Card Member)
+        if (
+            "date processed" in headers_lower
+            and "card member" in headers_lower
+            and any(h.strip() == "account #" for h in headers_lower)
+            and "merchant" in headers_lower
+            and "reference" in headers_lower
+        ):
+            return BankFormat.AMEX_MONTHLY_STATEMENT_CA
 
         # Monarch Money detection (very specific pattern)
         if (
@@ -297,7 +317,7 @@ class CSVParserService:
             transaction_date = datetime.strptime(date_str, mapping.date_format)
         except ValueError:
             # Try common formats as fallback
-            for fmt in ["%Y-%m-%d", "%m/%d/%Y", "%d/%m/%Y", "%Y/%m/%d"]:
+            for fmt in ["%Y-%m-%d", "%m/%d/%Y", "%d/%m/%Y", "%Y/%m/%d", "%d %b %Y"]:
                 try:
                     transaction_date = datetime.strptime(date_str, fmt)
                     break

--- a/backend/services/wealthsimple/importer.py
+++ b/backend/services/wealthsimple/importer.py
@@ -174,6 +174,8 @@ def _row_to_transaction_type(kind: RowKind, amount: Decimal) -> str:
         return TransactionType.TRANSFER.value
     if kind in {RowKind.TRANSFER_IN, RowKind.TRANSFER_OUT, RowKind.SHARE_TRANSFER}:
         return TransactionType.TRANSFER.value
+    if kind == RowKind.SPEND:
+        return TransactionType.EXPENSE.value if amount < 0 else TransactionType.INCOME.value
     if amount >= 0:
         return TransactionType.INCOME.value
     return TransactionType.EXPENSE.value
@@ -191,6 +193,7 @@ _KIND_CATEGORY: dict[RowKind, str] = {
     RowKind.TRANSFER_OUT: "transfer",
     RowKind.SHARE_TRANSFER: "share_transfer",
     RowKind.GIVEAWAY: "giveaway",
+    RowKind.SPEND: "cash_spend",
     RowKind.BUY: "investment",
     RowKind.SELL: "investment",
     RowKind.CC_PURCHASE: "credit_card_purchase",

--- a/backend/services/wealthsimple/row_parser.py
+++ b/backend/services/wealthsimple/row_parser.py
@@ -50,6 +50,7 @@ class RowKind(str, enum.Enum):
     DEPOSIT = "deposit"
     SHARE_TRANSFER = "share_transfer"
     GIVEAWAY = "giveaway"
+    SPEND = "spend"  # debit-card / bill pay from cash (chequing)
     # Credit card row kinds
     CC_PURCHASE = "cc_purchase"
     CC_REFUND = "cc_refund"
@@ -87,9 +88,11 @@ _SHAPE_A_MAP: dict[str, RowKind] = {
     "EFTOUT": RowKind.WITHDRAW,
     "WD": RowKind.WITHDRAW,
     "TRFIN": RowKind.TRANSFER_IN,
+    "TRFINTF": RowKind.TRANSFER_IN,  # tax-free / registered transfer in
     "TRFOUT": RowKind.TRANSFER_OUT,
     "TRFOUTTF": RowKind.SHARE_TRANSFER,
     "GIVEAWAY": RowKind.GIVEAWAY,
+    "SPEND": RowKind.SPEND,
 }
 
 

--- a/backend/tests/test_csv_amex_monthly_ca.py
+++ b/backend/tests/test_csv_amex_monthly_ca.py
@@ -1,0 +1,59 @@
+"""Amex Canada monthly statement CSV (website export) — synthetic rows only."""
+
+from datetime import datetime
+
+from backend.models.csv_import import BankFormat, CSVImportConfig
+from backend.services.csv_parser import CSVParserService
+
+# Minimal valid rows: same column layout as production export, no real PII
+SAMPLE = """Date,Date Processed,Description,Card Member,Account #,Amount,Foreign Spend Amount,Commission,Exchange Rate,Additional Information,Merchant,Address,City / Province,Postal Code,Country,Reference
+10 Apr 2026,10 Apr 2026,COFFEE SHOP           TORONTO,MEMBER A,-52003,5.25,,,,,COFFEE SHOP           TORONTO,1 MAIN ST,"TORONTO
+ON",M5V 1A1,CANADA,'REF1'
+12 Apr 2026,12 Apr 2026,REFUND MERCHANT       TORONTO,MEMBER A,-52003,-5.25,,,,,REFUND MERCHANT       TORONTO,1 MAIN ST,"TORONTO
+ON",M5V 1A1,CANADA,'REF2'
+"""
+
+
+def test_detect_amex_monthly_ca():
+    svc = CSVParserService()
+    headers = [
+        "Date",
+        "Date Processed",
+        "Description",
+        "Card Member",
+        "Account #",
+        "Amount",
+        "Foreign Spend Amount",
+        "Commission",
+        "Exchange Rate",
+        "Additional Information",
+        "Merchant",
+        "Address",
+        "City / Province",
+        "Postal Code",
+        "Country",
+        "Reference",
+    ]
+    assert svc.detect_bank_format(headers) == BankFormat.AMEX_MONTHLY_STATEMENT_CA
+
+
+def test_parse_amex_monthly_charge_and_refund():
+    svc = CSVParserService()
+    mapping = svc.BANK_FORMATS[BankFormat.AMEX_MONTHLY_STATEMENT_CA]
+    config = CSVImportConfig(
+        bank_format=BankFormat.AMEX_MONTHLY_STATEMENT_CA,
+        field_mapping=mapping,
+        default_currency="CAD",
+    )
+    preview = svc.parse_csv_file(SAMPLE, config, existing_transactions=[])
+    assert preview.total_rows == 2
+    assert preview.valid_rows == 2
+    a, b = preview.transactions
+    assert a.description.startswith("COFFEE")
+    assert a.amount == 5.25
+    assert a.type == "expense"
+    assert a.date == datetime(2026, 4, 10)
+    assert a.account == "-52003"
+    assert a.merchant and "COFFEE" in (a.merchant or "")
+    assert b.type == "income"
+    assert b.amount == 5.25

--- a/backend/tests/test_wealthsimple_importer.py
+++ b/backend/tests/test_wealthsimple_importer.py
@@ -52,6 +52,13 @@ CHEQUING_CSV = (
     '"2025-12-22","EFTOUT","Withdrawal","-1000.00","3000.00","CAD"\n'
 )
 
+# Shape-A codes SPEND (cash debit) and TRFINTF (registered transfer in) — no rows_unknown
+REGISTERED_CSV = (
+    '"date","transaction","description","amount","balance","currency"\n'
+    '"2026-02-01","TRFINTF","Tax-free transfer in","500.00","500.00","CAD"\n'
+    '"2026-02-02","SPEND","Merchant","-12.34","487.66","CAD"\n'
+)
+
 
 CC_CSV = (
     '"transaction_date","post_date","type","details","amount","currency"\n'
@@ -107,6 +114,21 @@ def test_buy_row_creates_lot_and_ticker_asset(db: Session) -> None:
     assert len(lots) == 1
     assert lots[0].quantity == Decimal("0.2994")
     assert lots[0].price_per_unit == Decimal("191.55")
+
+
+def test_shape_a_spend_and_trfintf_are_known_kinds(db: Session) -> None:
+    summary = WealthsimpleImporter(db).ingest(
+        [
+            (
+                "TFSA-monthly-statement-transactions-HQB2DBYK0CAD-2026-02-01.csv",
+                REGISTERED_CSV,
+            )
+        ]
+    )
+    db.commit()
+    assert summary.files[0].rows_unknown == 0
+    assert summary.files[0].by_kind.get("spend") == 1
+    assert summary.files[0].by_kind.get("transfer_in") == 1
 
 
 def test_chequing_file_creates_bank_asset(db: Session) -> None:

--- a/frontend/components/layout/MobileNav.tsx
+++ b/frontend/components/layout/MobileNav.tsx
@@ -7,6 +7,7 @@ import {
   Wallet,
   Menu,
   UploadCloud,
+  DollarSign,
 } from "lucide-react";
 import { cn } from "@/utils/cn";
 
@@ -17,6 +18,7 @@ const mobileNavItems = [
   { name: "Home", href: "/", icon: Home },
   { name: "Import", href: "/portfolio/wealthsimple-import", icon: UploadCloud },
   { name: "Holdings", href: "/portfolio", icon: TrendingUp },
+  { name: "Txns", href: "/transactions", icon: DollarSign },
   { name: "Accounts", href: "/accounts", icon: Wallet },
   { name: "More", href: "/settings", icon: Menu },
 ];
@@ -51,6 +53,8 @@ export default function MobileNav() {
                   path === "/import" ||
                   path.startsWith("/import/")
                 )
+              : item.href === "/transactions"
+                ? path === "/transactions"
               : item.href === "/settings"
                 ? path === "/settings" || path.startsWith("/settings/")
                 : path === item.href ||

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -29,6 +29,7 @@ const primaryNavigation = [
   { name: "Dashboard", href: "/", icon: Home },
   { name: "Holdings", href: "/portfolio", icon: TrendingUp },
   { name: "Accounts", href: "/accounts", icon: Wallet },
+  { name: "Transactions", href: "/transactions", icon: DollarSign },
   { name: "Insights", href: "/insights", icon: Target },
   { name: "Annual Report", href: "/report", icon: BarChart2 },
   { name: "Integrations", href: "/settings/integrations", icon: Plug },
@@ -41,8 +42,6 @@ const importNavigation = [
   { name: "Bank CSV import", href: "/import", icon: Upload },
   { name: "Import snapshot", href: "/portfolio/import", icon: Upload },
 ];
-
-const advancedNavigation = [{ name: "Transactions", href: "/transactions", icon: DollarSign }];
 
 interface NavItem {
   name: string;
@@ -69,9 +68,7 @@ interface RenderSectionArgs {
   router: ReturnType<typeof useRouter>;
 }
 
-// Shared rendering for the collapsible Advanced / Legacy sections.
-// Keeps both groups visually identical while letting each own its own
-// expand/collapse state.
+// Shared rendering for the collapsible Import section.
 function renderSection({
   title,
   items,
@@ -143,7 +140,6 @@ export default function Sidebar({ onCommandPaletteOpen }: SidebarProps) {
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const [importOpen, setImportOpen] = useState(true);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
   const { privacyMode, togglePrivacyMode, hydrated: privacyHydrated } = usePrivacyMode();
 
   useEffect(() => {
@@ -328,15 +324,6 @@ export default function Sidebar({ onCommandPaletteOpen }: SidebarProps) {
             items: importNavigation,
             open: importOpen,
             setOpen: setImportOpen,
-            isCollapsed,
-            router,
-          })}
-
-          {renderSection({
-            title: "Advanced",
-            items: advancedNavigation,
-            open: advancedOpen,
-            setOpen: setAdvancedOpen,
             isCollapsed,
             router,
           })}

--- a/frontend/pages/import.tsx
+++ b/frontend/pages/import.tsx
@@ -72,6 +72,7 @@ const bankFormats = [
   { value: "generic", label: "Generic CSV" },
   { value: "monarch", label: "Monarch Money" },
   { value: "amex_year_end_summary", label: "Amex Year-End Summary (CA)" },
+  { value: "amex_monthly_statement_ca", label: "Amex Monthly Statement (CA)" },
   { value: "wealthsimple", label: "Wealthsimple" },
   { value: "rbc", label: "RBC" },
   { value: "td_bank", label: "TD" },

--- a/frontend/pages/settings/integrations.tsx
+++ b/frontend/pages/settings/integrations.tsx
@@ -376,6 +376,7 @@ function QuestradeCard({ integration }: { integration: Integration }) {
   const [isSyncing, setIsSyncing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
+  const [serverTokenConfigured, setServerTokenConfigured] = useState(false);
   const [accounts, setAccounts] = useState<{ number: string; type: string; status: string }[]>([]);
   const [syncResult, setSyncResult] = useState<{
     accounts_synced: number;
@@ -393,22 +394,38 @@ function QuestradeCard({ integration }: { integration: Integration }) {
       setConnected(true);
       setRefreshToken(token);
     }
+    const root = integrationsRoot();
+    if (!root) return;
+    fetch(`${root}/questrade/status`)
+      .then((r) => r.json())
+      .then((data: { connected?: boolean }) => {
+        if (data.connected) setServerTokenConfigured(true);
+      })
+      .catch(() => {});
   }, []);
 
+  const questradeBrowserToken = () =>
+    (typeof window !== "undefined" ? localStorage.getItem(QUESTRADE_TOKEN_KEY) : null) || refreshToken;
+
+  const questradeRequestBody = () => {
+    const fromBrowser = questradeBrowserToken().trim();
+    return fromBrowser ? { refresh_token: fromBrowser } : {};
+  };
+
   const handleConnect = async () => {
-    if (!refreshToken.trim()) return;
     const root = integrationsRoot();
     if (!root) {
       setError(missingApiUrlMessage());
       return;
     }
+    if (!refreshToken.trim() && !serverTokenConfigured) return;
     setIsConnecting(true);
     setError(null);
     try {
       const res = await fetch(`${root}/questrade/test-connection`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refresh_token: refreshToken.trim() }),
+        body: JSON.stringify(questradeRequestBody()),
       });
       if (!res.ok) {
         const d = await res.json().catch(() => ({}));
@@ -425,7 +442,7 @@ function QuestradeCard({ integration }: { integration: Integration }) {
       setAccounts(data.accounts || []);
     } catch (e: unknown) {
       setError(integrationNetworkError(e));
-      setConnected(false);
+      if (!serverTokenConfigured) setConnected(false);
     } finally {
       setIsConnecting(false);
     }
@@ -433,15 +450,18 @@ function QuestradeCard({ integration }: { integration: Integration }) {
 
   const handleDisconnect = () => {
     localStorage.removeItem(QUESTRADE_TOKEN_KEY);
-    setConnected(false);
     setAccounts([]);
     setSyncResult(null);
     setRefreshToken("");
+    if (!serverTokenConfigured) setConnected(false);
   };
 
   const handleSync = async () => {
-    const token = localStorage.getItem(QUESTRADE_TOKEN_KEY) || refreshToken;
-    if (!token) { setError("No token. Connect first."); return; }
+    const hasBrowserToken = !!questradeBrowserToken().trim();
+    if (!hasBrowserToken && !serverTokenConfigured) {
+      setError("No token. Paste a refresh token, connect, or set QUESTRADE_REFRESH_TOKEN on the API (e.g. Vault).");
+      return;
+    }
     const root = integrationsRoot();
     if (!root) {
       setError(missingApiUrlMessage());
@@ -454,7 +474,7 @@ function QuestradeCard({ integration }: { integration: Integration }) {
       const res = await fetch(`${root}/questrade/sync`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refresh_token: token }),
+        body: JSON.stringify(questradeRequestBody()),
       });
       if (!res.ok) {
         const d = await res.json().catch(() => ({}));
@@ -484,7 +504,9 @@ function QuestradeCard({ integration }: { integration: Integration }) {
             </div>
           </div>
           <div className="flex items-center gap-3">
-            <StatusBadge status={connected ? "connected" : "disconnected"} />
+            <StatusBadge
+              status={connected || serverTokenConfigured ? "connected" : "disconnected"}
+            />
             <ChevronRight className={cn("w-5 h-5 text-slate-400 transition-transform", isExpanded && "rotate-90")} />
           </div>
         </div>
@@ -509,6 +531,13 @@ function QuestradeCard({ integration }: { integration: Integration }) {
               <div className="pt-4 space-y-4">
                 <SetupInstructions steps={integration.setupSteps} docsUrl={integration.docsUrl} />
 
+                {serverTokenConfigured && (
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    API has <code className="text-xs">QUESTRADE_REFRESH_TOKEN</code> (e.g. from Vault). You can use
+                    Connect / Sync without pasting; a token in the field overrides the server copy.
+                  </p>
+                )}
+
                 <div>
                   <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
                     Refresh Token
@@ -521,7 +550,7 @@ function QuestradeCard({ integration }: { integration: Integration }) {
                       placeholder="Paste your Questrade refresh token..."
                       className="flex-1"
                     />
-                    {connected ? (
+                    {questradeBrowserToken().trim() ? (
                       <Button variant="danger" onClick={(e) => { e.stopPropagation(); handleDisconnect(); }}>
                         Disconnect
                       </Button>
@@ -529,7 +558,7 @@ function QuestradeCard({ integration }: { integration: Integration }) {
                       <Button
                         variant="primary"
                         onClick={(e) => { e.stopPropagation(); handleConnect(); }}
-                        disabled={!refreshToken.trim() || isConnecting}
+                        disabled={(!refreshToken.trim() && !serverTokenConfigured) || isConnecting}
                       >
                         {isConnecting ? "Connecting..." : "Connect"}
                       </Button>
@@ -537,7 +566,7 @@ function QuestradeCard({ integration }: { integration: Integration }) {
                   </div>
                 </div>
 
-                {connected && (
+                {(connected || serverTokenConfigured) && (
                   <div className="flex items-center gap-3">
                     <Button
                       variant="secondary"

--- a/frontend/pages/transactions.tsx
+++ b/frontend/pages/transactions.tsx
@@ -44,6 +44,8 @@ interface Transaction {
   import_source?: string;
 }
 
+const API_URL = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "");
+
 const CATEGORIES = [
   "Food & Dining",
   "Shopping",
@@ -100,7 +102,7 @@ export default function Transactions() {
       if (accountFilter !== "all") params.set("account", accountFilter);
       params.set("limit", "2000");
 
-      const res = await fetch(`/v1/transactions/?${params.toString()}`);
+      const res = await fetch(`${API_URL}/v1/transactions/?${params.toString()}`);
       const data = await res.json();
       setTransactions(Array.isArray(data) ? data : []);
     } catch (err) {
@@ -128,7 +130,7 @@ export default function Transactions() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch("/v1/transactions/", {
+      const res = await fetch(`${API_URL}/v1/transactions/`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -149,7 +151,7 @@ export default function Transactions() {
 
   const handleDelete = async (id: number) => {
     try {
-      const res = await fetch(`/v1/transactions/${id}`, { method: "DELETE" });
+      const res = await fetch(`${API_URL}/v1/transactions/${id}`, { method: "DELETE" });
       if (res.ok) {
         await fetchTransactions();
       }

--- a/k8s/deploy.yaml
+++ b/k8s/deploy.yaml
@@ -46,6 +46,18 @@ spec:
               value: "redis://canopy-redis:6379/0"
             - name: ENVIRONMENT
               value: "production"
+            - name: QUESTRADE_REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: canopy-secrets
+                  key: questrade-refresh-token
+                  optional: true
+            - name: WISE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: canopy-secrets
+                  key: wise-api-token
+                  optional: true
           resources:
             requests:
               memory: "256Mi"

--- a/k8s/secrets-template.yaml
+++ b/k8s/secrets-template.yaml
@@ -9,7 +9,11 @@ stringData:
   database-url: "postgresql+psycopg://canopy:CHANGE_ME@canopy-postgres:5432/canopy"
   postgres-password: "CHANGE_ME"
   secret-key: "CHANGE_ME_GENERATE_STRONG_KEY"
-  
+  # Optional — API reads these via env (map keys to QUESTRADE_REFRESH_TOKEN / WISE_API_TOKEN in deploy).
+  # Prefer HashiCorp Vault + External Secrets Operator: sync Vault paths into this Secret, never commit values.
+  # questrade-refresh-token: ""
+  # wise-api-token: ""
+
 # To create the secret:
 # 1. Copy this file to secrets.yaml
 # 2. Replace CHANGE_ME values with actual secrets


### PR DESCRIPTION
- CSV: Amex Canada monthly statement preset, detection, import UI label; tests + guide
- Wealthsimple: SPEND + TRFINTF shape-A codes; Questrade QUESTRADE_REFRESH_TOKEN + GET /questrade/status + integrations UI for Vault token
- Navigation: Transactions in primary sidebar and mobile bar
- k8s: optional questrade/wise secret keys in deploy template

Made-with: Cursor
