### PR TITLE
fix: Conditional concurrency - fast dev, safe prod

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -25,7 +25,8 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Cancel old builds for PRs (speed), but never cancel main/tags (safety - all images needed)
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-api:


### PR DESCRIPTION
Implements smart concurrency: cancel PRs, never cancel main/tags.

## Change
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Behavior
- ✅ **PRs:** Old builds cancelled (velocidade)
- ✅ **Main:** Never cancel (segurança)
- ✅ **Tags:** Never cancel (releases completos)

## Why
- `create-git-tag: true` requires ALL main builds to complete
- Prevents gaps in GHCR registry (missing commit images)
- Dev speed in PRs, production safety in main

## Before
Main pushes cancelled each other → missing images

## After  
PRs fast (cancel), main safe (all images)